### PR TITLE
Fix raw_records reference when saving generated slates

### DIFF
--- a/src/pydfs/api/__init__.py
+++ b/src/pydfs/api/__init__.py
@@ -2259,6 +2259,7 @@ def create_app() -> FastAPI:
         site = slate_inputs["resolved_site"]
         sport = slate_inputs["resolved_sport"]
         records: list[PlayerRecord] = slate_inputs["records"]
+        raw_records: list[PlayerRecord] = slate_inputs["raw_records"]
         mapping_report: MappingPreviewResponse = slate_inputs["report"]
         slate_obj = slate_inputs["slate"]
         effective_players_mapping = slate_inputs["effective_players_mapping"]


### PR DESCRIPTION
## Summary
- capture the raw player records returned from slate preparation
- ensure new slates store the correct raw record payload during lineup builds

## Testing
- pytest (fails: ModuleNotFoundError: No module named 'pydfs')

------
https://chatgpt.com/codex/tasks/task_b_68decb32b8208328a813a070367ee749