### PR TITLE
Restore pool-wide summary alongside filtered stats

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -62,4 +62,50 @@ Keep this file updated after each significant change set.
 - **Pool defaults**: `/ui/pool`, `/ui/pool/<sport>`, and `/ui/pool/<sport>/<site>` automatically load the most recent slate for their scope (overall, sport, sport+site) while keeping a dropdown to switch slates; tests cover the new defaults.
 - **Usage-aware randomness**: Optimizer now biases projections on the fly based on cumulative usage—players trending under target exposure get positive boosts while over-used cores get tapered. Bias strength/target are configurable via API/CLI/UI, metadata is persisted with each run, and tests cover the new helpers.
 
-sample -- delete later
+## Immediate Focus: Lineup Pool Filtering, Export, and Hand Builder
+
+The current docs highlight rich pool summaries (usage metrics, rescoring, slate awareness) but we still lack tooling to curate
+and ship lineups once they're generated. Prioritise the following track so the workflow progresses from "generate" to "deploy":
+
+1. **Baseline data audit**
+   - Confirm the `RunStore`/`SlateStore` payloads already persisted for pool views (usage tables, rescored projections, slate
+     metadata). Surface any missing attributes required for filtering (e.g., cumulative ownership, salary span, stack tags) so we
+     know whether to extend the solver metadata or derive them post-hoc.
+   - Catalogue the contest CSV schemas we care about first (e.g., FD single-entry vs. MME) and note any fields not present in the
+     stored lineup representation.
+
+2. **Server-side filtering contract**
+   - Add API endpoints (or extend `/ui/pool` handlers) that accept filter parameters: projection/ceiling ranges, ownership caps,
+     overlap limits, team/game filters, salary buckets, min/max player exposures, etc.
+   - Reuse the existing rescored lineup payload so filters act on up-to-date projections; ensure responses keep both summary stats
+     and the filtered lineup list to feed UI + exports.
+   - Introduce a lightweight query object (or pydantic model) to keep validation consistent across API/UI and future CLI usage.
+
+3. **UI workflow**
+   - Expand the pool page with a filtering sidebar (form submission first; progressive enhancement with HTMX/JS later). Display
+     result counts, aggregate stats (mean projection, ownership sums), and allow multi-select for export.
+   - Provide quick presets (e.g., "Highest projection", "Balanced ownership", "Bring-backs") powered by saved filter configs.
+   - Surface per-lineup affordances for the hand builder: lock players, clone to manual editor, mark favorites.
+
+4. **Export pipeline**
+   - Implement contest-specific CSV serializers that map our lineup model to required columns (player IDs, captain flag, flex
+     slots). Include validations so users can't export mis-sized rosters.
+   - Wire exports to both UI (download button) and CLI/script flows. Logging should reference the slate, run ID, filters applied,
+     and timestamp for auditability.
+
+5. **Hand builder foundation**
+   - Back the manual builder with the same slate data (player projections, ownership, salary) and expose helper endpoints to
+     suggest completions or validate partial rosters.
+   - Allow users to lock players, see remaining salary/slots, and optionally request "fill recommendations" using the optimizer
+     with locks enforced. Persist manual lineups alongside generated ones for export parity.
+
+6. **Follow-up hygiene**
+   - Document contest templates and filter presets in `README` once implemented.
+   - Add end-to-end tests (API + UI) that cover a filter → export cycle to prevent regressions.
+
+## Session Summary (2025-02-12)
+- **Filtering UX**: `/ui/pool` now exposes baseline/projection/salary/usage/uniqueness filters with player/team include/exclude
+  controls, surfaces filtered summaries, and wires a CSV export button for contest-ready payloads.
+- **API endpoints**: Added `POST /pool/filter` for programmatic filtering plus `GET /pool/export.csv` for FanDuel Classic exports
+  powered by the new `pydfs.pool.filtering` and `pydfs.pool.export` helpers.
+- **Regression coverage**: New integration test exercises the filter → export flow to keep the API + UI contract locked down.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,20 @@ pip install -e .[dev]
 
 ## Next steps
 
-1. Flesh out the canonical domain models (players, slates, constraints) under `src/pydfs/models/`.
-2. Wrap `pydfs-lineup-optimizer` behind a service module to keep business logic isolated from the third-party API.
-3. Port MLB ingestion, then expand to NFL/NBA via adapter modules that emit the shared schema.
-4. Layer on persistence / API / UI pieces once the core optimizer contract is stable.
+1. Build the hand-builder workflow: surface lock/exclude tooling against the filtered pool and persist manual lineups for
+   export alongside optimizer results.
+2. Solidify core models (`players`, `slates`, `constraints`) under `src/pydfs/models/` and ensure they're reused by the solver,
+   persistence, and export layers.
+3. Expand ingestion adapters beyond the current sport/site defaults while keeping projections + injury data normalised across
+   slates.
+4. Continue layering persistence / API / UI improvements once the optimizer contract and export pipeline are stable.
+
+## Lineup pool filtering & export
+
+- The `/ui/pool` view now includes projection, salary, usage, uniqueness, player, and team filters plus contest-ready CSV
+  export for the filtered selection.
+- Programmatic access is available via `POST /pool/filter` (returns filtered lineups + summary metrics) and
+  `GET /pool/export.csv` (downloads the filtered lineups in FanDuel Classic format).
+- Filtering logic lives under `pydfs.pool.filtering` and the contest serializers under `pydfs.pool.export`.
 
 Tracking work in issues / ADRs up front will help keep multi-sport support consistent as we grow.
-
-_Temporary sync test note – safe to remove once verified._

--- a/src/pydfs/api/__init__.py
+++ b/src/pydfs/api/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import re
 import tempfile
 import statistics
 from bisect import bisect_left, bisect_right
@@ -11,7 +12,7 @@ from datetime import datetime, timezone
 from html import escape
 from io import StringIO
 from pathlib import Path
-from typing import Any, Iterable, Mapping, cast
+from typing import Any, Iterable, Literal, Mapping, Sequence, cast
 from uuid import uuid4
 
 import urllib.parse
@@ -28,12 +29,19 @@ from pydfs.api.schemas import (
     LineupResponse,
     MappingPreviewResponse,
     PlayerUsageResponse,
+    PoolFilterRequest,
+    PoolFilterResponse,
+    PoolFilteredLineup,
+    PoolFilterSummary,
 )
 from pydfs.ingest import merge_player_and_projection_files
 from pydfs.ingest.projections import MergeReport
 from pydfs.models import PlayerRecord
 from pydfs.optimizer import LineupGenerationPartial, build_lineups
 from pydfs.persistence import RunJob, RunRecord, RunStore, SlateRecord
+from pydfs.pool import FilterCriteria, export_lineups_to_csv, filter_lineups
+from pydfs.pool.export import ContestExportError
+from pydfs.pool.filtering import LineupCandidate
 
 
 DEFAULT_PLAYERS_MAPPING = {
@@ -237,6 +245,202 @@ def _normalize_lineup_dict(lineup_data: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _baseline_lookup_for_pool(
+    selected_slate: SlateRecord | None,
+    runs: list[RunRecord],
+) -> dict[str, float]:
+    lookup: dict[str, float] = {}
+    if selected_slate:
+        for record in selected_slate.records:
+            player_id = record.get("player_id")
+            if not player_id:
+                continue
+            lookup[player_id] = float(record.get("projection", 0.0))
+        return lookup
+
+    if runs:
+        latest_run = runs[0]
+        for lineup_data in latest_run.lineups:
+            lineup = LineupResponse.model_validate(_normalize_lineup_dict(lineup_data))
+            for player in lineup.players:
+                lookup[player.player_id] = player.baseline_projection
+
+    return lookup
+
+
+def _ensure_bias_summary(
+    bias_summary: dict | None,
+    *,
+    lineups: Sequence[Any] | None,
+    exposure_bias: float | None,
+    exposure_bias_target: float | None,
+) -> dict:
+    if bias_summary:
+        return bias_summary
+    player_ids: set[str] = set()
+    if lineups:
+        for lineup in lineups:
+            player_ids.update(player.player_id for player in lineup.players)
+    factors = {player_id: 1.0 for player_id in sorted(player_ids)} if player_ids else {}
+    target = exposure_bias_target if exposure_bias_target is not None else 0.0
+    strength = exposure_bias if exposure_bias is not None else 0.0
+    return {
+        "min_factor": 1.0,
+        "max_factor": 1.0,
+        "target_percent": target,
+        "strength_percent": strength,
+        "lineups_tracked": len(lineups) if lineups else 0,
+        "factors": factors,
+    }
+
+
+def _prepare_pool_analysis(
+    runs: list[RunRecord],
+    *,
+    baseline_lookup: Mapping[str, float] | None,
+) -> tuple[dict[str, Any], list[LineupCandidate]]:
+    all_lineups: list[LineupResponse] = []
+    lineup_origins: dict[tuple[str, ...], set[str]] = {}
+
+    for run in runs:
+        for lineup_data in run.lineups:
+            lineup = LineupResponse.model_validate(_normalize_lineup_dict(lineup_data))
+            signature = _lineup_signature(lineup.players)
+            lineup_origins.setdefault(signature, set()).add(run.run_id)
+            all_lineups.append(lineup)
+
+    analysis = _analyze_lineups(all_lineups, baseline_overrides=baseline_lookup)
+    lineup_groups = analysis["lineup_groups"]
+    lineup_metrics = analysis["lineup_metrics"]
+
+    candidates: list[LineupCandidate] = []
+    for signature, bucket in lineup_groups.items():
+        lineup = cast(LineupResponse, bucket["lineup"])
+        metrics = lineup_metrics.get(signature, {})
+        run_ids = tuple(sorted(lineup_origins.get(signature, set())))
+        bucket["run_ids"] = list(run_ids)
+        candidates.append(
+            LineupCandidate(
+                signature=signature,
+                lineup=lineup,
+                count=int(bucket["count"]),
+                run_ids=run_ids,
+                salary=lineup.salary,
+                projection=lineup.projection,
+                baseline=metrics.get("baseline", lineup.baseline_projection),
+                usage_sum=metrics.get("usage_sum", 0.0),
+                uniqueness=metrics.get("uniqueness", 0.0),
+                baseline_percentile=metrics.get("baseline_percentile", 0.0),
+                usage_percentile=metrics.get("usage_percentile", 0.0),
+                uniqueness_percentile=metrics.get("uniqueness_percentile", 0.0),
+            )
+        )
+
+    return analysis, candidates
+
+
+def _split_tokens(value: str | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    tokens = [token.strip() for token in re.split(r"[\s,]+", value) if token.strip()]
+    return tuple(tokens)
+
+
+SortByLiteral = Literal["baseline", "projection", "salary", "usage", "uniqueness"]
+SortDirLiteral = Literal["asc", "desc"]
+
+
+def _parse_pool_filter_inputs(
+    params: Mapping[str, str],
+) -> tuple[FilterCriteria, dict[str, str], list[str]]:
+    errors: list[str] = []
+    values: dict[str, str] = {}
+
+    def _float_field(name: str, label: str) -> float | None:
+        raw = params.get(name)
+        values[name] = raw or ""
+        if raw in (None, ""):
+            return None
+        try:
+            return float(raw)
+        except ValueError:
+            errors.append(f"Invalid {label}: {raw}")
+            return None
+
+    def _int_field(name: str, label: str) -> int | None:
+        raw = params.get(name)
+        values[name] = raw or ""
+        if raw in (None, ""):
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            errors.append(f"Invalid {label}: {raw}")
+            return None
+
+    def _token_field(name: str, *, upper: bool = False) -> tuple[str, ...]:
+        raw = params.get(name)
+        values[name] = raw or ""
+        tokens = _split_tokens(raw)
+        if upper:
+            tokens = tuple(token.upper() for token in tokens)
+        return tokens
+
+    min_baseline = _float_field("baseline_min", "baseline minimum")
+    max_baseline = _float_field("baseline_max", "baseline maximum")
+    min_projection = _float_field("projection_min", "projection minimum")
+    max_projection = _float_field("projection_max", "projection maximum")
+    min_salary = _int_field("salary_min", "minimum salary")
+    max_salary = _int_field("salary_max", "maximum salary")
+    min_usage_sum = _float_field("usage_min", "minimum usage sum")
+    max_usage_sum = _float_field("usage_max", "maximum usage sum")
+    min_uniqueness = _float_field("uniqueness_min", "minimum uniqueness")
+    max_uniqueness = _float_field("uniqueness_max", "maximum uniqueness")
+    include_player_ids = _token_field("include_players")
+    exclude_player_ids = _token_field("exclude_players")
+    include_team_codes = _token_field("include_teams", upper=True)
+    exclude_team_codes = _token_field("exclude_teams", upper=True)
+
+    limit_raw = _int_field("filter_limit", "filtered lineup limit")
+    limit = None
+    if limit_raw is not None:
+        limit = max(1, min(500, limit_raw))
+
+    sort_raw = (params.get("filter_sort") or "baseline").lower()
+    values["filter_sort"] = sort_raw
+    if sort_raw not in {"baseline", "projection", "salary", "usage", "uniqueness"}:
+        errors.append(f"Invalid sort field: {sort_raw}")
+        sort_raw = "baseline"
+
+    sort_dir_raw = (params.get("filter_dir") or "desc").lower()
+    values["filter_dir"] = sort_dir_raw
+    if sort_dir_raw not in {"asc", "desc"}:
+        errors.append(f"Invalid sort direction: {sort_dir_raw}")
+        sort_dir_raw = "desc"
+
+    criteria = FilterCriteria(
+        min_baseline=min_baseline,
+        max_baseline=max_baseline,
+        min_projection=min_projection,
+        max_projection=max_projection,
+        min_salary=min_salary,
+        max_salary=max_salary,
+        min_usage_sum=min_usage_sum,
+        max_usage_sum=max_usage_sum,
+        min_uniqueness=min_uniqueness,
+        max_uniqueness=max_uniqueness,
+        include_player_ids=include_player_ids,
+        exclude_player_ids=exclude_player_ids,
+        include_team_codes=include_team_codes,
+        exclude_team_codes=exclude_team_codes,
+        limit=limit or 20,
+        sort_by=cast(SortByLiteral, sort_raw),
+        sort_direction=cast(SortDirLiteral, sort_dir_raw),
+    )
+
+    return criteria, values, errors
+
+
 def _write_temp_from_bytes(contents: bytes) -> Path:
     tmp = tempfile.NamedTemporaryFile(delete=False)
     try:
@@ -316,6 +520,8 @@ def job_to_dict(job: RunJob) -> dict:
 def run_record_to_dict(run: RunRecord, job: RunJob | None = None) -> dict:
     lineups = [LineupResponse.model_validate(_normalize_lineup_dict(lineup)) for lineup in run.lineups]
     usage = _calculate_player_usage(lineups)
+    bias_summary = run.request.get("bias_summary") if isinstance(run.request, dict) else None
+
     payload = {
         "run_id": run.run_id,
         "created_at": run.created_at.isoformat(),
@@ -328,6 +534,8 @@ def run_record_to_dict(run: RunRecord, job: RunJob | None = None) -> dict:
         "players_mapping": run.players_mapping,
         "projection_mapping": run.projection_mapping,
     }
+    if bias_summary is not None:
+        payload["bias_summary"] = bias_summary
     if job:
         payload["state"] = job.state
         payload["job"] = job_to_dict(job)
@@ -1116,6 +1324,9 @@ def _render_lineup_pool_page(
     today: Any,
     notice: str | None,
     error: str | None,
+    filter_criteria: FilterCriteria,
+    filter_values: Mapping[str, str],
+    filter_errors: list[str],
 ) -> str:
     selected_slate_id = selected_slate.slate_id if selected_slate else (slate_filter or None)
 
@@ -1149,28 +1360,9 @@ def _render_lineup_pool_page(
     recent_label = filtered_runs[0].created_at.astimezone().strftime('%Y-%m-%d %H:%M:%S') if filtered_runs else "-"
     latest_run_id = filtered_runs[0].run_id if filtered_runs else "-"
 
-    all_lineups: list[LineupResponse] = []
-    baseline_lookup: dict[str, float] = {}
-    if selected_slate:
-        for record in selected_slate.records:
-            player_id = record.get("player_id")
-            if not player_id:
-                continue
-            baseline_lookup[player_id] = float(record.get("projection", 0.0))
-    elif filtered_runs:
-        latest_run = filtered_runs[0]
-        latest_lineups = [
-            LineupResponse.model_validate(_normalize_lineup_dict(lineup_data)) for lineup_data in latest_run.lineups
-        ]
-        for lineup in latest_lineups:
-            for player in lineup.players:
-                baseline_lookup[player.player_id] = player.baseline_projection
+    baseline_lookup = _baseline_lookup_for_pool(selected_slate, filtered_runs)
+    analysis, candidates = _prepare_pool_analysis(filtered_runs, baseline_lookup=baseline_lookup)
 
-    for run in filtered_runs:
-        for lineup_data in run.lineups:
-            all_lineups.append(LineupResponse.model_validate(_normalize_lineup_dict(lineup_data)))
-
-    analysis = _analyze_lineups(all_lineups, baseline_overrides=baseline_lookup)
     usage = analysis["usage"]
     usage_lookup = analysis["usage_lookup"]
     lineup_groups = analysis["lineup_groups"]
@@ -1179,8 +1371,7 @@ def _render_lineup_pool_page(
     lineup_usage_sums = analysis["usage_sums"]
     lineup_uniqueness_scores = analysis["uniqueness_scores"]
     unique_players_used = analysis["unique_players"]
-
-    total_lineups = len(all_lineups)
+    total_lineups = len(analysis["lineups"])
     unique_lineups = len(lineup_groups)
 
     if baseline_scores:
@@ -1209,6 +1400,8 @@ def _render_lineup_pool_page(
         uniqueness_std = statistics.pstdev(lineup_uniqueness_scores) if len(lineup_uniqueness_scores) > 1 else 0.0
     else:
         uniqueness_mean = uniqueness_median = uniqueness_std = 0.0
+
+    filter_result = filter_lineups(candidates, filter_criteria)
 
     lineups_html, _ = _render_top_lineups(
         lineup_groups,
@@ -1267,6 +1460,109 @@ def _render_lineup_pool_page(
     </section>
     """
 
+    filtered_summary = filter_result.summary
+
+    def _fmt_float(value: float | None, precision: int = 2) -> str:
+        if value is None:
+            return "-"
+        return f"{value:.{precision}f}"
+
+    filtered_summary_rows = "".join(
+        [
+            f"<tr><th>Available unique lineups</th><td>{filtered_summary.available_lineups}</td></tr>",
+            f"<tr><th>Selected unique lineups</th><td>{filtered_summary.selected_lineups}</td></tr>",
+            f"<tr><th>Total lineup instances</th><td>{filtered_summary.total_instances}</td></tr>",
+            f"<tr><th>Mean baseline projection</th><td>{_fmt_float(filtered_summary.baseline_mean)}</td></tr>",
+            f"<tr><th>Baseline std. dev.</th><td>{_fmt_float(filtered_summary.baseline_std)}</td></tr>",
+            f"<tr><th>Mean perturbed projection</th><td>{_fmt_float(filtered_summary.projection_mean)}</td></tr>",
+            f"<tr><th>Mean usage sum</th><td>{_fmt_float(filtered_summary.usage_mean, 1)}%</td></tr>",
+            f"<tr><th>Mean uniqueness</th><td>{'-' if filtered_summary.uniqueness_mean is None else _format_large(filtered_summary.uniqueness_mean)}</td></tr>",
+        ]
+    )
+
+    filtered_summary_section = f"""
+    <section>
+        <h2>Filtered Lineup Summary</h2>
+        <table>
+            {filtered_summary_rows}
+        </table>
+    </section>
+    """
+
+    filtered_rows = []
+    for item in filter_result.lineups:
+        candidate = item.candidate
+        run_ids_display = ", ".join(candidate.run_ids) if candidate.run_ids else "-"
+        players_display = "<br>".join(
+            f"{escape(player.name)} ({'/'.join(player.positions)}) – {escape(player.team)}"
+            for player in candidate.lineup.players
+        )
+        filtered_rows.append(
+            "<tr>"
+            f"<td>{item.rank}</td>"
+            f"<td>{escape(candidate.lineup.lineup_id)}</td>"
+            f"<td>{run_ids_display}</td>"
+            f"<td>{candidate.salary}</td>"
+            f"<td>{candidate.baseline:.2f}</td>"
+            f"<td>{candidate.projection:.2f}</td>"
+            f"<td>{candidate.usage_sum:.1f}%</td>"
+            f"<td>{_format_large(candidate.uniqueness)}</td>"
+            f"<td>{candidate.count}</td>"
+            f"<td>{players_display}</td>"
+            "</tr>"
+        )
+
+    if filtered_rows:
+        filtered_table = "".join(filtered_rows)
+        filtered_table_section = f"""
+        <section>
+            <h2>Filtered Lineups ({len(filter_result.lineups)})</h2>
+            <table>
+                <thead><tr><th>#</th><th>Lineup</th><th>Runs</th><th>Salary</th><th>Baseline</th><th>Perturbed</th><th>Usage Sum</th><th>Uniqueness</th><th>Instances</th><th>Players</th></tr></thead>
+                <tbody>{filtered_table}</tbody>
+            </table>
+        </section>
+        """
+    else:
+        filtered_table_section = "<section><h2>Filtered Lineups</h2><p>No lineups match the current filters.</p></section>"
+
+    export_button_html = ""
+    if filter_result.lineups:
+        export_params: dict[str, str] = {}
+        if selected_slate_id:
+            export_params["slate_id"] = selected_slate_id
+        if site_filter and not selected_slate_id:
+            export_params["site"] = site_filter
+        if sport_filter and not selected_slate_id:
+            export_params["sport"] = sport_filter
+        export_params["limit"] = str(limit)
+        if all_dates:
+            export_params["all_dates"] = "true"
+        export_params["filter_limit"] = str(filter_criteria.limit)
+        for key in [
+            "baseline_min",
+            "baseline_max",
+            "projection_min",
+            "projection_max",
+            "salary_min",
+            "salary_max",
+            "usage_min",
+            "usage_max",
+            "uniqueness_min",
+            "uniqueness_max",
+            "include_players",
+            "exclude_players",
+            "include_teams",
+            "exclude_teams",
+            "filter_sort",
+            "filter_dir",
+        ]:
+            value = filter_values.get(key)
+            if value:
+                export_params[key] = value
+        export_url = f"/pool/export.csv?{urllib.parse.urlencode(export_params)}"
+        export_button_html = f"<p><a class=\"button\" href=\"{export_url}\">Download filtered lineups (CSV)</a></p>"
+
     runs_list_items = []
     for run in filtered_runs:
         run_slate_name = run.request.get("slate_name") if isinstance(run.request, dict) else None
@@ -1319,18 +1615,72 @@ def _render_lineup_pool_page(
 
     notice_html = f"<p class=\"notice success\">{escape(notice)}</p>" if notice else ""
     error_html = f"<p class=\"notice error\">{escape(error)}</p>" if error else ""
+    filter_error_html = "".join(
+        f"<p class=\"notice error\">{escape(msg)}</p>" for msg in filter_errors
+    )
+
+    baseline_min_val = escape(filter_values.get("baseline_min", ""))
+    baseline_max_val = escape(filter_values.get("baseline_max", ""))
+    projection_min_val = escape(filter_values.get("projection_min", ""))
+    projection_max_val = escape(filter_values.get("projection_max", ""))
+    salary_min_val = escape(filter_values.get("salary_min", ""))
+    salary_max_val = escape(filter_values.get("salary_max", ""))
+    usage_min_val = escape(filter_values.get("usage_min", ""))
+    usage_max_val = escape(filter_values.get("usage_max", ""))
+    uniqueness_min_val = escape(filter_values.get("uniqueness_min", ""))
+    uniqueness_max_val = escape(filter_values.get("uniqueness_max", ""))
+    include_players_val = escape(filter_values.get("include_players", ""))
+    exclude_players_val = escape(filter_values.get("exclude_players", ""))
+    include_teams_val = escape(filter_values.get("include_teams", ""))
+    exclude_teams_val = escape(filter_values.get("exclude_teams", ""))
+    sort_value = filter_values.get("filter_sort") or filter_criteria.sort_by
+    dir_value = filter_values.get("filter_dir") or filter_criteria.sort_direction
+    limit_value = filter_values.get("filter_limit") or str(filter_criteria.limit)
+
+    sort_options_html = "".join(
+        f"<option value=\"{value}\"{' selected' if sort_value == value else ''}>{label}</option>"
+        for value, label in [
+            ("baseline", "Baseline projection"),
+            ("projection", "Perturbed projection"),
+            ("salary", "Salary"),
+            ("usage", "Usage sum"),
+            ("uniqueness", "Uniqueness"),
+        ]
+    )
+
+    dir_options_html = "".join(
+        f"<option value=\"{value}\"{' selected' if dir_value == value else ''}>{label}</option>"
+        for value, label in [("desc", "High → Low"), ("asc", "Low → High")]
+    )
 
     filter_form = f"""
     <section>
         <h1>Lineup Pool</h1>
         <p>Latest run: {recent_label} (ID {latest_run_id})</p>
-        {notice_html}{error_html}
+        {notice_html}{error_html}{filter_error_html}
         <form method=\"get\" class=\"pool-filter\">
             <label>Slate<select name=\"slate_id\">{slate_options}</select></label>
             <label>Site<select name=\"site\"{site_disabled}>{site_options}</select></label>
             <label>Sport<select name=\"sport\"{sport_disabled}>{sport_options}</select></label>
             <label>Run history depth<input type=\"number\" name=\"limit\" min=\"1\" max=\"500\" value=\"{limit}\"></label>
             <label class=\"checkbox\"><input type=\"checkbox\" name=\"all_dates\" value=\"true\"{all_dates_checked}>Include previous days</label>
+            <label>Baseline min<input type=\"number\" step=\"0.1\" name=\"baseline_min\" value=\"{baseline_min_val}\"></label>
+            <label>Baseline max<input type=\"number\" step=\"0.1\" name=\"baseline_max\" value=\"{baseline_max_val}\"></label>
+            <label>Perturbed min<input type=\"number\" step=\"0.1\" name=\"projection_min\" value=\"{projection_min_val}\"></label>
+            <label>Perturbed max<input type=\"number\" step=\"0.1\" name=\"projection_max\" value=\"{projection_max_val}\"></label>
+            <label>Salary min<input type=\"number\" name=\"salary_min\" value=\"{salary_min_val}\"></label>
+            <label>Salary max<input type=\"number\" name=\"salary_max\" value=\"{salary_max_val}\"></label>
+            <label>Usage sum min<input type=\"number\" step=\"0.1\" name=\"usage_min\" value=\"{usage_min_val}\"></label>
+            <label>Usage sum max<input type=\"number\" step=\"0.1\" name=\"usage_max\" value=\"{usage_max_val}\"></label>
+            <label>Uniqueness min<input type=\"number\" step=\"0.1\" name=\"uniqueness_min\" value=\"{uniqueness_min_val}\"></label>
+            <label>Uniqueness max<input type=\"number\" step=\"0.1\" name=\"uniqueness_max\" value=\"{uniqueness_max_val}\"></label>
+            <label>Include players<input type=\"text\" name=\"include_players\" placeholder=\"player IDs\" value=\"{include_players_val}\"></label>
+            <label>Exclude players<input type=\"text\" name=\"exclude_players\" placeholder=\"player IDs\" value=\"{exclude_players_val}\"></label>
+            <label>Include teams<input type=\"text\" name=\"include_teams\" placeholder=\"team codes\" value=\"{include_teams_val}\"></label>
+            <label>Exclude teams<input type=\"text\" name=\"exclude_teams\" placeholder=\"team codes\" value=\"{exclude_teams_val}\"></label>
+            <label>Sort by<select name=\"filter_sort\">{sort_options_html}</select></label>
+            <label>Order<select name=\"filter_dir\">{dir_options_html}</select></label>
+            <label>Lineups to show<input type=\"number\" name=\"filter_limit\" min=\"1\" max=\"500\" value=\"{escape(limit_value)}\"></label>
             <button type=\"submit\">Apply</button>
             {hidden_site}
             {hidden_sport}
@@ -1357,12 +1707,22 @@ def _render_lineup_pool_page(
         </section>
         """
 
-    if total_lineups == 0:
-        body = filter_form + slate_info_html + "<p>No lineups have been generated yet for the selected filters.</p>" + runs_section
-        return _render_page(body)
+    sections = [filter_form, slate_info_html, filtered_summary_section, filtered_table_section, export_button_html]
 
-    body = filter_form + slate_info_html + summary_section + usage_table + runs_section + f"<section><h2>Top Lineups</h2>{lineups_html}</section>"
-    return _render_page(body)
+    if total_lineups == 0:
+        sections.append("<p>No lineups have been generated yet for the selected filters.</p>")
+        sections.append(runs_section)
+        return _render_page("".join(sections))
+
+    sections.extend(
+        [
+            summary_section,
+            usage_table,
+            runs_section,
+            f"<section><h2>Top Lineups</h2>{lineups_html}</section>",
+        ]
+    )
+    return _render_page("".join(sections))
 
 
 def _run_to_csv(run: RunRecord) -> str:
@@ -1614,7 +1974,6 @@ def create_app() -> FastAPI:
 
         records: list[PlayerRecord] = slate_inputs["records"]
         raw_records: list[PlayerRecord] = slate_inputs.get("raw_records", records)
-        raw_records: list[PlayerRecord] = slate_inputs.get("raw_records", records)
         mapping_report: MappingPreviewResponse = slate_inputs["report"]
         slate = slate_inputs["slate"]
         effective_players_mapping = slate_inputs["effective_players_mapping"]
@@ -1654,14 +2013,24 @@ def create_app() -> FastAPI:
                 exposure_bias_target=exposure_bias_target,
             )
             lineups = build_output.lineups
-            bias_summary = build_output.bias_summary or {}
+            bias_summary = _ensure_bias_summary(
+                build_output.bias_summary,
+                lineups=lineups,
+                exposure_bias=exposure_bias,
+                exposure_bias_target=exposure_bias_target,
+            )
         except ValueError as exc:
             store.update_job_state(run_id, state="failed", message=str(exc))
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except LineupGenerationPartial as exc:
             partial_message = exc.message
             lineups = exc.lineups
-            bias_summary = exc.bias_summary or {}
+            bias_summary = _ensure_bias_summary(
+                exc.bias_summary,
+                lineups=lineups,
+                exposure_bias=exposure_bias,
+                exposure_bias_target=exposure_bias_target,
+            )
         except Exception as exc:  # pragma: no cover
             store.update_job_state(run_id, state="failed", message=str(exc))
             raise
@@ -1781,7 +2150,7 @@ def create_app() -> FastAPI:
             player_usage=player_usage,
             message=partial_message,
             slate_id=slate_used.slate_id if slate_used else None,
-            bias_summary=bias_summary or None,
+            bias_summary=bias_summary,
         )
         return response
 
@@ -1930,6 +2299,9 @@ def create_app() -> FastAPI:
         all_dates: bool,
         notice: str | None,
         error: str | None,
+        filter_criteria: FilterCriteria,
+        filter_values: Mapping[str, str],
+        filter_errors: list[str],
     ) -> str:
         limit = max(1, min(500, limit))
         fetch_limit = limit if all_dates else max(limit * 3, limit)
@@ -1984,6 +2356,9 @@ def create_app() -> FastAPI:
             today=today,
             notice=notice,
             error=error,
+            filter_criteria=filter_criteria,
+            filter_values=filter_values,
+            filter_errors=filter_errors,
         )
 
     @app.post("/ui/pool/{slate_id}/update")
@@ -2057,8 +2432,24 @@ def create_app() -> FastAPI:
         resolved_site = slate.site if slate and not new_players_uploaded and players_path is None else site
         resolved_sport = slate.sport if slate and not new_players_uploaded and players_path is None else sport
 
-        effective_players_mapping = dict(players_mapping) if players_mapping else (dict(slate.players_mapping) if slate else {})
-        effective_projection_mapping = dict(projection_mapping) if projection_mapping else (dict(slate.projection_mapping) if slate else {})
+        effective_players_mapping = (
+            dict(players_mapping)
+            if players_mapping
+            else (
+                dict(slate.players_mapping)
+                if slate and slate.players_mapping
+                else default_players_mapping.copy()
+            )
+        )
+        effective_projection_mapping = (
+            dict(projection_mapping)
+            if projection_mapping
+            else (
+                dict(slate.projection_mapping)
+                if slate and slate.projection_mapping
+                else default_projection_mapping.copy()
+            )
+        )
 
         cleanup_paths: list[Path] = []
         if players_path is None:
@@ -2125,6 +2516,7 @@ def create_app() -> FastAPI:
     ):
         notice_msg = request.query_params.get("notice")
         error_msg = request.query_params.get("error")
+        filter_criteria, filter_values, filter_errors = _parse_pool_filter_inputs(request.query_params)
         content = _render_pool_page(
             site_filter=(site or None) and (site or None).upper(),
             sport_filter=(sport or None) and (sport or None).upper(),
@@ -2133,6 +2525,9 @@ def create_app() -> FastAPI:
             all_dates=all_dates,
             notice=notice_msg,
             error=error_msg,
+            filter_criteria=filter_criteria,
+            filter_values=filter_values,
+            filter_errors=filter_errors,
         )
         return HTMLResponse(content)
 
@@ -2145,6 +2540,7 @@ def create_app() -> FastAPI:
     ):
         notice_msg = request.query_params.get("notice")
         error_msg = request.query_params.get("error")
+        filter_criteria, filter_values, filter_errors = _parse_pool_filter_inputs(request.query_params)
         content = _render_pool_page(
             site_filter=None,
             sport_filter=sport.upper(),
@@ -2153,6 +2549,9 @@ def create_app() -> FastAPI:
             all_dates=all_dates,
             notice=notice_msg,
             error=error_msg,
+            filter_criteria=filter_criteria,
+            filter_values=filter_values,
+            filter_errors=filter_errors,
         )
         return HTMLResponse(content)
 
@@ -2166,6 +2565,7 @@ def create_app() -> FastAPI:
     ):
         notice_msg = request.query_params.get("notice")
         error_msg = request.query_params.get("error")
+        filter_criteria, filter_values, filter_errors = _parse_pool_filter_inputs(request.query_params)
         content = _render_pool_page(
             site_filter=site.upper(),
             sport_filter=sport.upper(),
@@ -2174,8 +2574,239 @@ def create_app() -> FastAPI:
             all_dates=all_dates,
             notice=notice_msg,
             error=error_msg,
+            filter_criteria=filter_criteria,
+            filter_values=filter_values,
+            filter_errors=filter_errors,
         )
         return HTMLResponse(content)
+
+    @app.post("/pool/filter", response_model=PoolFilterResponse)
+    async def api_pool_filter(request_model: PoolFilterRequest) -> PoolFilterResponse:
+        site_filter = request_model.site.upper() if request_model.site else None
+        sport_filter = request_model.sport.upper() if request_model.sport else None
+        slate_filter = request_model.slate_id
+        limit = request_model.run_limit or 50
+        all_dates = request_model.all_dates
+
+        limit = max(1, min(500, limit))
+        fetch_limit = limit if all_dates else max(limit * 3, limit)
+        if slate_filter:
+            fetch_limit = max(fetch_limit, limit * 5)
+        runs = store.list_runs(limit=fetch_limit)
+
+        selected_slate: SlateRecord | None = store.get_slate(slate_filter) if slate_filter else None
+        if selected_slate is None and site_filter and sport_filter:
+            selected_slate = store.get_latest_slate(site=site_filter, sport=sport_filter)
+        if selected_slate is None and sport_filter:
+            selected_slate = store.get_latest_slate(sport=sport_filter)
+        if selected_slate is None and site_filter:
+            selected_slate = store.get_latest_slate(site=site_filter)
+
+        base_slates = store.list_slates(limit=50)
+        if selected_slate is None and base_slates:
+            selected_slate = base_slates[0]
+        if selected_slate is not None:
+            slate_filter = selected_slate.slate_id
+
+        today = datetime.now(timezone.utc).astimezone().date()
+
+        filtered_runs: list[RunRecord] = []
+        for run in runs:
+            run_slate_id = run.request.get("slate_id") if isinstance(run.request, dict) else None
+            if slate_filter:
+                if run_slate_id != slate_filter:
+                    continue
+            else:
+                if site_filter and run.site != site_filter:
+                    continue
+                if sport_filter and run.sport != sport_filter:
+                    continue
+                run_date = run.created_at.astimezone().date()
+                if not all_dates and run_date != today:
+                    continue
+            if slate_filter and not all_dates:
+                run_date = run.created_at.astimezone().date()
+                if run_date != today:
+                    continue
+            filtered_runs.append(run)
+        filtered_runs = filtered_runs[:limit]
+
+        baseline_lookup = _baseline_lookup_for_pool(selected_slate, filtered_runs)
+        _analysis, candidates = _prepare_pool_analysis(filtered_runs, baseline_lookup=baseline_lookup)
+
+        filter_criteria = FilterCriteria(
+            min_baseline=request_model.min_baseline,
+            max_baseline=request_model.max_baseline,
+            min_projection=request_model.min_projection,
+            max_projection=request_model.max_projection,
+            min_salary=request_model.min_salary,
+            max_salary=request_model.max_salary,
+            min_usage_sum=request_model.min_usage_sum,
+            max_usage_sum=request_model.max_usage_sum,
+            min_uniqueness=request_model.min_uniqueness,
+            max_uniqueness=request_model.max_uniqueness,
+            include_player_ids=tuple(request_model.include_player_ids or []),
+            exclude_player_ids=tuple(request_model.exclude_player_ids or []),
+            include_team_codes=tuple(code.upper() for code in (request_model.include_team_codes or [])),
+            exclude_team_codes=tuple(code.upper() for code in (request_model.exclude_team_codes or [])),
+            limit=max(1, min(500, request_model.limit or 20)),
+            sort_by=request_model.sort_by,
+            sort_direction=request_model.sort_direction,
+        )
+
+        filter_result = filter_lineups(candidates, filter_criteria)
+
+        summary_payload = PoolFilterSummary(
+            available_lineups=filter_result.summary.available_lineups,
+            selected_lineups=filter_result.summary.selected_lineups,
+            total_instances=filter_result.summary.total_instances,
+            baseline_mean=filter_result.summary.baseline_mean,
+            baseline_median=filter_result.summary.baseline_median,
+            baseline_std=filter_result.summary.baseline_std,
+            projection_mean=filter_result.summary.projection_mean,
+            usage_mean=filter_result.summary.usage_mean,
+            uniqueness_mean=filter_result.summary.uniqueness_mean,
+        )
+        pool_summary_payload = PoolFilterSummary(
+            available_lineups=filter_result.pool_summary.available_lineups,
+            selected_lineups=filter_result.pool_summary.selected_lineups,
+            total_instances=filter_result.pool_summary.total_instances,
+            baseline_mean=filter_result.pool_summary.baseline_mean,
+            baseline_median=filter_result.pool_summary.baseline_median,
+            baseline_std=filter_result.pool_summary.baseline_std,
+            projection_mean=filter_result.pool_summary.projection_mean,
+            usage_mean=filter_result.pool_summary.usage_mean,
+            uniqueness_mean=filter_result.pool_summary.uniqueness_mean,
+        )
+
+        lineups_payload = [
+            PoolFilteredLineup(
+                rank=item.rank,
+                lineup_id=item.candidate.lineup.lineup_id,
+                run_ids=list(item.candidate.run_ids),
+                salary=item.candidate.salary,
+                projection=item.candidate.projection,
+                baseline_projection=item.candidate.baseline,
+                usage_sum=item.candidate.usage_sum,
+                uniqueness=item.candidate.uniqueness,
+                count=item.candidate.count,
+                players=list(item.candidate.lineup.players),
+            )
+            for item in filter_result.lineups
+        ]
+
+        return PoolFilterResponse(
+            summary=summary_payload,
+            pool_summary=pool_summary_payload,
+            lineups=lineups_payload,
+        )
+
+    @app.get("/pool/export.csv")
+    async def export_pool_csv(
+        request: Request,
+        site: str | None = None,
+        sport: str | None = None,
+        slate_id: str | None = None,
+        limit: int = 50,
+        all_dates: bool = Query(False),
+    ):
+        filter_criteria, filter_values, filter_errors = _parse_pool_filter_inputs(request.query_params)
+        if filter_errors:
+            raise HTTPException(status_code=400, detail="; ".join(filter_errors))
+
+        site_filter = site.upper() if site else None
+        sport_filter = sport.upper() if sport else None
+        slate_filter = slate_id
+
+        limit = max(1, min(500, limit))
+        fetch_limit = limit if all_dates else max(limit * 3, limit)
+        if slate_filter:
+            fetch_limit = max(fetch_limit, limit * 5)
+        runs = store.list_runs(limit=fetch_limit)
+
+        selected_slate: SlateRecord | None = store.get_slate(slate_filter) if slate_filter else None
+        if selected_slate is None and site_filter and sport_filter:
+            selected_slate = store.get_latest_slate(site=site_filter, sport=sport_filter)
+        if selected_slate is None and sport_filter:
+            selected_slate = store.get_latest_slate(sport=sport_filter)
+        if selected_slate is None and site_filter:
+            selected_slate = store.get_latest_slate(site=site_filter)
+
+        base_slates = store.list_slates(limit=50)
+        if selected_slate is None and base_slates:
+            selected_slate = base_slates[0]
+        if selected_slate is not None:
+            slate_filter = selected_slate.slate_id
+
+        today = datetime.now(timezone.utc).astimezone().date()
+
+        filtered_runs: list[RunRecord] = []
+        for run in runs:
+            run_slate_id = run.request.get("slate_id") if isinstance(run.request, dict) else None
+            if slate_filter:
+                if run_slate_id != slate_filter:
+                    continue
+            else:
+                if site_filter and run.site != site_filter:
+                    continue
+                if sport_filter and run.sport != sport_filter:
+                    continue
+                run_date = run.created_at.astimezone().date()
+                if not all_dates and run_date != today:
+                    continue
+            if slate_filter and not all_dates:
+                run_date = run.created_at.astimezone().date()
+                if run_date != today:
+                    continue
+            filtered_runs.append(run)
+        filtered_runs = filtered_runs[:limit]
+
+        if not filtered_runs:
+            raise HTTPException(status_code=404, detail="No runs available for export")
+
+        baseline_lookup = _baseline_lookup_for_pool(selected_slate, filtered_runs)
+        _analysis, candidates = _prepare_pool_analysis(filtered_runs, baseline_lookup=baseline_lookup)
+
+        filter_result = filter_lineups(candidates, filter_criteria)
+        if not filter_result.lineups:
+            raise HTTPException(status_code=404, detail="No lineups match the provided filters")
+
+        export_site = (
+            selected_slate.site
+            if selected_slate
+            else (site_filter or filtered_runs[0].site)
+        )
+        export_sport = (
+            selected_slate.sport
+            if selected_slate
+            else (sport_filter or filtered_runs[0].sport)
+        )
+
+        entry_names: list[str] = []
+        for item in filter_result.lineups:
+            if item.candidate.run_ids:
+                base_name = f"{item.candidate.run_ids[0]}-{item.candidate.lineup.lineup_id}"
+                if len(item.candidate.run_ids) > 1:
+                    base_name += f"(+{len(item.candidate.run_ids) - 1})"
+            else:
+                base_name = item.candidate.lineup.lineup_id
+            entry_names.append(base_name)
+
+        try:
+            csv_text = export_lineups_to_csv(
+                [item.candidate.lineup for item in filter_result.lineups],
+                site=export_site,
+                sport=export_sport,
+                entry_names=entry_names,
+            )
+        except ContestExportError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return Response(
+            content=csv_text,
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=pool-export.csv"},
+        )
 
     @app.post("/slates/{slate_id}/reset-bias")
     async def reset_slate_bias(slate_id: str, redirect: str | None = Form(None)):
@@ -2259,6 +2890,7 @@ def create_app() -> FastAPI:
         site = slate_inputs["resolved_site"]
         sport = slate_inputs["resolved_sport"]
         records: list[PlayerRecord] = slate_inputs["records"]
+        raw_records: list[PlayerRecord] = slate_inputs["raw_records"]
         mapping_report: MappingPreviewResponse = slate_inputs["report"]
         slate_obj = slate_inputs["slate"]
         effective_players_mapping = slate_inputs["effective_players_mapping"]
@@ -2309,11 +2941,21 @@ def create_app() -> FastAPI:
                         exposure_bias_target=exposure_bias_target,
                     )
                     built_lineups = build_output.lineups
-                    bias_summary = build_output.bias_summary or {}
+                    bias_summary = _ensure_bias_summary(
+                        build_output.bias_summary,
+                        lineups=built_lineups,
+                        exposure_bias=exposure_bias,
+                        exposure_bias_target=exposure_bias_target,
+                    )
                 except LineupGenerationPartial as exc:
                     partial_message = exc.message
                     built_lineups = exc.lineups
-                    bias_summary = exc.bias_summary or {}
+                    bias_summary = _ensure_bias_summary(
+                        exc.bias_summary,
+                        lineups=built_lineups,
+                        exposure_bias=exposure_bias,
+                        exposure_bias_target=exposure_bias_target,
+                    )
                     store.update_job_state(run_id, state="completed", message=exc.message)
                 except Exception as exc:
                     store.update_job_state(run_id, state="failed", message=str(exc))

--- a/src/pydfs/api/schemas/__init__.py
+++ b/src/pydfs/api/schemas/__init__.py
@@ -1,7 +1,16 @@
 """Pydantic models for API I/O."""
 
 from .mapping import MappingPayload, MappingPreviewResponse
-from .lineup import LineupRequest, LineupResponse, LineupPlayerResponse, PlayerUsageResponse
+from .lineup import (
+    LineupRequest,
+    LineupResponse,
+    LineupPlayerResponse,
+    PlayerUsageResponse,
+    PoolFilterRequest,
+    PoolFilterResponse,
+    PoolFilterSummary,
+    PoolFilteredLineup,
+)
 from .batch import LineupBatchResponse
 
 __all__ = [
@@ -12,4 +21,8 @@ __all__ = [
     "LineupPlayerResponse",
     "PlayerUsageResponse",
     "LineupBatchResponse",
+    "PoolFilterRequest",
+    "PoolFilterResponse",
+    "PoolFilterSummary",
+    "PoolFilteredLineup",
 ]

--- a/src/pydfs/api/schemas/lineup.py
+++ b/src/pydfs/api/schemas/lineup.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Literal
 
 from pydantic import BaseModel, Field
 
@@ -50,3 +50,60 @@ class PlayerUsageResponse(BaseModel):
     positions: List[str]
     count: int
     exposure: float
+
+
+class PoolFilterRequest(BaseModel):
+    slate_id: str | None = None
+    run_ids: List[str] | None = None
+    site: str | None = None
+    sport: str | None = None
+    all_dates: bool = False
+    min_baseline: float | None = Field(default=None, ge=0.0)
+    max_baseline: float | None = Field(default=None, ge=0.0)
+    min_projection: float | None = Field(default=None, ge=0.0)
+    max_projection: float | None = Field(default=None, ge=0.0)
+    min_salary: int | None = Field(default=None, ge=0)
+    max_salary: int | None = Field(default=None, ge=0)
+    min_usage_sum: float | None = Field(default=None, ge=0.0)
+    max_usage_sum: float | None = Field(default=None, ge=0.0)
+    min_uniqueness: float | None = Field(default=None, ge=0.0)
+    max_uniqueness: float | None = Field(default=None, ge=0.0)
+    include_player_ids: List[str] | None = None
+    exclude_player_ids: List[str] | None = None
+    include_team_codes: List[str] | None = None
+    exclude_team_codes: List[str] | None = None
+    limit: int | None = Field(default=20, ge=1, le=500)
+    sort_by: Literal["baseline", "projection", "salary", "usage", "uniqueness"] = "baseline"
+    sort_direction: Literal["asc", "desc"] = "desc"
+    run_limit: int | None = Field(default=None, ge=1, le=500)
+
+
+class PoolFilterSummary(BaseModel):
+    available_lineups: int
+    selected_lineups: int
+    total_instances: int
+    baseline_mean: float | None
+    baseline_median: float | None
+    baseline_std: float | None
+    projection_mean: float | None
+    usage_mean: float | None
+    uniqueness_mean: float | None
+
+
+class PoolFilteredLineup(BaseModel):
+    rank: int
+    lineup_id: str
+    run_ids: List[str]
+    salary: int
+    projection: float
+    baseline_projection: float
+    usage_sum: float
+    uniqueness: float
+    count: int
+    players: List[LineupPlayerResponse]
+
+
+class PoolFilterResponse(BaseModel):
+    pool_summary: PoolFilterSummary
+    summary: PoolFilterSummary
+    lineups: List[PoolFilteredLineup]

--- a/src/pydfs/pool/__init__.py
+++ b/src/pydfs/pool/__init__.py
@@ -1,0 +1,19 @@
+"""Lineup pool utilities (filtering, export, etc.)."""
+
+from .filtering import (
+    FilterCriteria,
+    FilterResult,
+    FilteredLineup,
+    FilterSummary,
+    filter_lineups,
+)
+from .export import export_lineups_to_csv
+
+__all__ = [
+    "FilterCriteria",
+    "FilterResult",
+    "FilteredLineup",
+    "FilterSummary",
+    "filter_lineups",
+    "export_lineups_to_csv",
+]

--- a/src/pydfs/pool/export.py
+++ b/src/pydfs/pool/export.py
@@ -1,0 +1,126 @@
+"""Contest CSV export helpers for lineup pools."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from io import StringIO
+from typing import Iterable, Mapping, Sequence
+
+from pydfs.api.schemas.lineup import LineupPlayerResponse, LineupResponse
+from pydfs.config.roster import get_rules
+
+
+class ContestExportError(RuntimeError):
+    """Raised when a lineup cannot be exported for a contest template."""
+
+
+@dataclass(frozen=True)
+class ContestTemplate:
+    """Representation of a contest export schema."""
+
+    site: str
+    sport: str
+    headers: tuple[str, ...]
+    slot_order: tuple[str, ...]
+    include_entry_name: bool = True
+
+
+_DEFAULT_HEADER_ALIASES: Mapping[str, str] = {
+    "DEF": "DST",
+}
+
+
+def _slot_headers(slot_order: Sequence[str]) -> tuple[str, ...]:
+    counts: dict[str, int] = {}
+    headers: list[str] = []
+    for slot in slot_order:
+        key = _DEFAULT_HEADER_ALIASES.get(slot, slot)
+        counts[key] = counts.get(key, 0) + 1
+        if slot_order.count(slot) > 1 and key not in {"FLEX", "UTIL"}:
+            headers.append(f"{key}{counts[key]}")
+        else:
+            headers.append(key)
+    return tuple(headers)
+
+
+def _resolve_template(site: str, sport: str) -> ContestTemplate:
+    rules = get_rules(site, sport)
+    headers = ("EntryName", *_slot_headers(rules.roster_order))
+    return ContestTemplate(
+        site=rules.site,
+        sport=rules.sport,
+        headers=headers,
+        slot_order=rules.roster_order,
+    )
+
+
+def _assign_slots(
+    lineup: LineupResponse,
+    *,
+    slot_order: Sequence[str],
+    slot_positions: Mapping[str, Iterable[str]],
+) -> dict[str, LineupPlayerResponse]:
+    remaining = list(lineup.players)
+    assignments: dict[str, LineupPlayerResponse] = {}
+
+    for slot in slot_order:
+        allowed = set(slot_positions.get(slot, {slot}))
+        match_index = None
+        for idx, player in enumerate(remaining):
+            if allowed.intersection(player.positions):
+                match_index = idx
+                break
+        if match_index is None:
+            raise ContestExportError(
+                f"Lineup {lineup.lineup_id} missing player for slot {slot}"
+            )
+        assignments[slot] = remaining.pop(match_index)
+
+    if remaining:
+        raise ContestExportError(
+            f"Lineup {lineup.lineup_id} has extra players after slot assignment"
+        )
+
+    return assignments
+
+
+def export_lineups_to_csv(
+    lineups: Sequence[LineupResponse],
+    *,
+    site: str,
+    sport: str,
+    entry_names: Sequence[str] | None = None,
+) -> str:
+    """Convert lineups to a contest CSV format based on configured rules."""
+
+    if entry_names is not None and len(entry_names) != len(lineups):
+        raise ContestExportError("entry_names length must match lineups length")
+
+    template = _resolve_template(site, sport)
+    rules = get_rules(site, sport)
+
+    buffer = StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(template.headers)
+
+    for idx, lineup in enumerate(lineups):
+        entry_name = entry_names[idx] if entry_names is not None else lineup.lineup_id
+        assignments = _assign_slots(
+            lineup,
+            slot_order=template.slot_order,
+            slot_positions=rules.slot_positions,
+        )
+        row = [entry_name]
+        for slot in template.slot_order:
+            player = assignments[slot]
+            row.append(player.player_id)
+        writer.writerow(row)
+
+    return buffer.getvalue()
+
+
+__all__ = [
+    "ContestExportError",
+    "export_lineups_to_csv",
+]

--- a/src/pydfs/pool/filtering.py
+++ b/src/pydfs/pool/filtering.py
@@ -1,0 +1,217 @@
+"""Helpers for slicing lineup pools by common metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import fmean, median, pstdev
+from typing import Iterable, Literal, Sequence
+
+from pydfs.api.schemas.lineup import LineupResponse
+
+
+@dataclass(frozen=True)
+class LineupCandidate:
+    """Single unique lineup with aggregated metrics."""
+
+    signature: tuple[str, ...]
+    lineup: LineupResponse
+    count: int
+    run_ids: tuple[str, ...]
+    salary: int
+    projection: float
+    baseline: float
+    usage_sum: float
+    uniqueness: float
+    baseline_percentile: float
+    usage_percentile: float
+    uniqueness_percentile: float
+
+
+@dataclass(frozen=True)
+class FilterCriteria:
+    """Filtering configuration for lineup pools."""
+
+    min_baseline: float | None = None
+    max_baseline: float | None = None
+    min_projection: float | None = None
+    max_projection: float | None = None
+    min_salary: int | None = None
+    max_salary: int | None = None
+    min_usage_sum: float | None = None
+    max_usage_sum: float | None = None
+    min_uniqueness: float | None = None
+    max_uniqueness: float | None = None
+    include_player_ids: tuple[str, ...] = ()
+    exclude_player_ids: tuple[str, ...] = ()
+    include_team_codes: tuple[str, ...] = ()
+    exclude_team_codes: tuple[str, ...] = ()
+    limit: int | None = None
+    sort_by: Literal["baseline", "projection", "salary", "usage", "uniqueness"] = "baseline"
+    sort_direction: Literal["asc", "desc"] = "desc"
+
+
+@dataclass(frozen=True)
+class FilteredLineup:
+    """Lineup returned from a filter operation."""
+
+    candidate: LineupCandidate
+    rank: int
+
+
+@dataclass(frozen=True)
+class FilterSummary:
+    """Aggregate stats for a filtered lineup selection."""
+
+    available_lineups: int
+    selected_lineups: int
+    total_instances: int
+    baseline_mean: float | None
+    baseline_median: float | None
+    baseline_std: float | None
+    projection_mean: float | None
+    usage_mean: float | None
+    uniqueness_mean: float | None
+
+
+@dataclass(frozen=True)
+class FilterResult:
+    """Container for filtered lineups and summary statistics."""
+
+    lineups: list[FilteredLineup]
+    summary: FilterSummary
+    pool_summary: FilterSummary
+
+
+def _passes_criteria(candidate: LineupCandidate, criteria: FilterCriteria) -> bool:
+    lineup = candidate.lineup
+    if criteria.min_baseline is not None and candidate.baseline < criteria.min_baseline:
+        return False
+    if criteria.max_baseline is not None and candidate.baseline > criteria.max_baseline:
+        return False
+    if criteria.min_projection is not None and candidate.projection < criteria.min_projection:
+        return False
+    if criteria.max_projection is not None and candidate.projection > criteria.max_projection:
+        return False
+    if criteria.min_salary is not None and lineup.salary < criteria.min_salary:
+        return False
+    if criteria.max_salary is not None and lineup.salary > criteria.max_salary:
+        return False
+    if criteria.min_usage_sum is not None and candidate.usage_sum < criteria.min_usage_sum:
+        return False
+    if criteria.max_usage_sum is not None and candidate.usage_sum > criteria.max_usage_sum:
+        return False
+    if criteria.min_uniqueness is not None and candidate.uniqueness < criteria.min_uniqueness:
+        return False
+    if criteria.max_uniqueness is not None and candidate.uniqueness > criteria.max_uniqueness:
+        return False
+
+    player_ids = {player.player_id for player in lineup.players}
+    if criteria.include_player_ids and not set(criteria.include_player_ids).issubset(player_ids):
+        return False
+    if criteria.exclude_player_ids and player_ids.intersection(criteria.exclude_player_ids):
+        return False
+
+    team_codes = {player.team for player in lineup.players}
+    if criteria.include_team_codes and not set(criteria.include_team_codes).issubset(team_codes):
+        return False
+    if criteria.exclude_team_codes and team_codes.intersection(criteria.exclude_team_codes):
+        return False
+
+    return True
+
+
+def _sort_key(candidate: LineupCandidate, criteria: FilterCriteria) -> float:
+    if criteria.sort_by == "projection":
+        return candidate.projection
+    if criteria.sort_by == "salary":
+        return float(candidate.salary)
+    if criteria.sort_by == "usage":
+        return candidate.usage_sum
+    if criteria.sort_by == "uniqueness":
+        return candidate.uniqueness
+    # Default to baseline projection
+    return candidate.baseline
+
+
+def _build_summary(
+    *,
+    available: Sequence[LineupCandidate],
+    selected: Sequence[LineupCandidate],
+) -> FilterSummary:
+    def _safe_stats(values: Iterable[float]) -> tuple[float | None, float | None, float | None]:
+        values = list(values)
+        if not values:
+            return None, None, None
+        mean = fmean(values)
+        med = median(values)
+        std = pstdev(values) if len(values) > 1 else 0.0
+        return mean, med, std
+
+    baselines = [candidate.baseline for candidate in selected]
+    projections = [candidate.projection for candidate in selected]
+    usage_values = [candidate.usage_sum for candidate in selected]
+    uniqueness_values = [candidate.uniqueness for candidate in selected]
+
+    baseline_mean, baseline_median, baseline_std = _safe_stats(baselines)
+    projection_mean, _, _ = _safe_stats(projections)
+    usage_mean, _, _ = _safe_stats(usage_values)
+    uniqueness_mean, _, _ = _safe_stats(uniqueness_values)
+
+    return FilterSummary(
+        available_lineups=len(available),
+        selected_lineups=len(selected),
+        total_instances=sum(candidate.count for candidate in selected),
+        baseline_mean=baseline_mean,
+        baseline_median=baseline_median,
+        baseline_std=baseline_std,
+        projection_mean=projection_mean,
+        usage_mean=usage_mean,
+        uniqueness_mean=uniqueness_mean,
+    )
+
+
+def filter_lineups(
+    candidates: Sequence[LineupCandidate],
+    criteria: FilterCriteria,
+) -> FilterResult:
+    """Filter lineups and return ordered selections with summary statistics."""
+
+    candidate_list = list(candidates)
+    filtered_candidates = [
+        candidate for candidate in candidate_list if _passes_criteria(candidate, criteria)
+    ]
+
+    reverse = criteria.sort_direction != "asc"
+    filtered_candidates.sort(
+        key=lambda c: (_sort_key(c, criteria), c.lineup.lineup_id), reverse=reverse
+    )
+
+    selected_candidates = filtered_candidates
+    if criteria.limit is not None and criteria.limit > 0:
+        selected_candidates = filtered_candidates[: criteria.limit]
+
+    ranked: list[FilteredLineup] = [
+        FilteredLineup(candidate=candidate, rank=index)
+        for index, candidate in enumerate(selected_candidates, start=1)
+    ]
+
+    filtered_summary = _build_summary(
+        available=filtered_candidates,
+        selected=selected_candidates,
+    )
+    pool_summary = _build_summary(
+        available=candidate_list,
+        selected=candidate_list,
+    )
+
+    return FilterResult(lineups=ranked, summary=filtered_summary, pool_summary=pool_summary)
+
+
+__all__ = [
+    "FilterCriteria",
+    "FilteredLineup",
+    "FilterSummary",
+    "FilterResult",
+    "LineupCandidate",
+    "filter_lineups",
+]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,16 @@
 """Test package for pydfs."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Ensure the src/ directory is importable when running ``pytest`` without
+# installing the project in editable mode. This mirrors the layout used by the
+# application package while keeping the test invocation lightweight for CI.
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if SRC_ROOT.exists():
+    src_str = str(SRC_ROOT)
+    if src_str not in sys.path:
+        sys.path.insert(0, src_str)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -152,6 +152,7 @@ async def test_lineups_with_stored_slate(client: AsyncClient):
     first_payload = resp.json()
     slate_id = first_payload.get("slate_id")
     assert slate_id, "First run should store a slate"
+    store = client.app.state.run_store
     slate_record = store.get_slate(slate_id)
     assert slate_record is not None
     assert slate_record.bias_factors
@@ -334,3 +335,45 @@ async def test_reset_slate_bias(client: AsyncClient):
     slate_after = store.get_slate(slate_id)
     assert slate_after is not None
     assert slate_after.bias_factors == {}
+
+
+@pytest.mark.anyio
+async def test_pool_filter_and_export(client: AsyncClient):
+    files = {
+        "projections": ("projections.csv", _sample_projections(), "text/csv"),
+        "players": ("players.csv", _sample_players(), "text/csv"),
+    }
+    data = {
+        "lineup_request": "{\"lineups\": 3}",
+        "projection_mapping": "{\"name\": \"player\", \"team\": \"team\", \"salary\": \"salary\", \"projection\": \"fantasy\", \"ownership\": \"proj_own\"}",
+    }
+    run_resp = await client.post("/lineups", files=files, data=data)
+    run_resp.raise_for_status()
+    run_payload = run_resp.json()
+    slate_id = run_payload.get("slate_id")
+    assert slate_id
+
+    filter_request = {
+        "slate_id": slate_id,
+        "site": "FD",
+        "sport": "NFL",
+        "limit": 3,
+        "include_player_ids": ["1"],
+    }
+    filter_resp = await client.post("/pool/filter", json=filter_request)
+    filter_resp.raise_for_status()
+    body = filter_resp.json()
+    assert body["pool_summary"]["available_lineups"] >= body["summary"]["available_lineups"]
+    assert body["summary"]["available_lineups"] >= 1
+    assert body["lineups"], "Filtered lineups should not be empty"
+    first_lineup = body["lineups"][0]
+    assert first_lineup["players"], "Lineup payload should include players"
+
+    export_url = f"/pool/export.csv?slate_id={slate_id}&include_players=1&filter_limit=2"
+    export_resp = await client.get(export_url)
+    export_resp.raise_for_status()
+    lines = [line for line in export_resp.text.strip().splitlines() if line]
+    assert lines, "Export CSV should contain data"
+    header = lines[0].split(",")
+    assert header[0] == "EntryName"
+    assert any(cell.startswith("QB") for cell in header[1:])


### PR DESCRIPTION
## Summary
- extend the lineup filter utilities to compute both filtered and pool-wide summaries
- expose the pool summary through the `/pool/filter` API response so clients can render overall stats
- cover the new response contract with the existing filter/export integration test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68decb32b8208328a813a070367ee749