### PR TITLE
Fix FanDuel single-game roster ingestion for missing positions and expand lineup size

### DIFF
--- a/src/pydfs/api/schemas/lineup.py
+++ b/src/pydfs/api/schemas/lineup.py
@@ -50,6 +50,8 @@ class PlayerUsageResponse(BaseModel):
     positions: List[str]
     count: int
     exposure: float
+    baseline_projection: float
+    projection: float
 
 
 class PoolFilterRequest(BaseModel):

--- a/src/pydfs/config/roster.py
+++ b/src/pydfs/config/roster.py
@@ -51,6 +51,57 @@ _ROSTER_RULES: Dict[Tuple[str, str], RosterRules] = {
         team_max_players=4,
         stacking_slots={"QB", "RB", "WR", "TE", "FLEX"},
     ),
+    ("FD_SINGLE", "NFL"): RosterRules(
+        site="FD_SINGLE",
+        sport="NFL",
+        salary_cap=60_000,
+        roster_order=("MVP", "UTIL", "UTIL", "UTIL", "UTIL", "UTIL"),
+        slot_positions={
+            "MVP": {"MVP"},
+            "UTIL": {"QB", "RB", "WR", "TE", "K"},
+        },
+        team_max_players=4,
+        stacking_slots={"UTIL"},
+    ),
+    ("FD_SINGLE", "NBA"): RosterRules(
+        site="FD_SINGLE",
+        sport="NBA",
+        salary_cap=60_000,
+        roster_order=("MVP", "STAR", "PRO", "UTIL", "UTIL"),
+        slot_positions={
+            "MVP": {"MVP"},
+            "STAR": {"STAR"},
+            "PRO": {"PRO"},
+            "UTIL": {"PG", "SG", "SF", "PF", "C"},
+        },
+        team_max_players=4,
+        stacking_slots={"UTIL"},
+    ),
+    ("FD_SINGLE", "MLB"): RosterRules(
+        site="FD_SINGLE",
+        sport="MLB",
+        salary_cap=60_000,
+        roster_order=("MVP", "STAR", "UTIL", "UTIL", "UTIL"),
+        slot_positions={
+            "MVP": {"MVP"},
+            "STAR": {"STAR"},
+            "UTIL": {"1B", "2B", "3B", "SS", "OF", "C", "C/1B"},
+        },
+        team_max_players=4,
+        stacking_slots={"UTIL"},
+    ),
+    ("FD_SINGLE", "NHL"): RosterRules(
+        site="FD_SINGLE",
+        sport="NHL",
+        salary_cap=60_000,
+        roster_order=("CAPTAIN", "UTIL", "UTIL", "UTIL", "UTIL"),
+        slot_positions={
+            "CAPTAIN": {"CAPTAIN"},
+            "UTIL": {"C", "W", "D"},
+        },
+        team_max_players=4,
+        stacking_slots={"UTIL"},
+    ),
 }
 
 

--- a/src/pydfs/ingest/__init__.py
+++ b/src/pydfs/ingest/__init__.py
@@ -2,6 +2,7 @@
 
 from .projections import (
     ProjectionRow,
+    infer_site_variant,
     load_projection_csv,
     load_records_from_csv,
     merge_player_and_projection_files,
@@ -14,4 +15,5 @@ __all__ = [
     "merge_player_and_projection_files",
     "rows_to_records",
     "load_records_from_csv",
+    "infer_site_variant",
 ]

--- a/src/pydfs/optimizer/service.py
+++ b/src/pydfs/optimizer/service.py
@@ -13,8 +13,10 @@ from typing import Iterable, List, Optional, Sequence, Tuple, Mapping
 
 from pydfs_lineup_optimizer import Site, Sport, get_optimizer
 from pydfs_lineup_optimizer.lineup import Lineup
+from pydfs_lineup_optimizer.player_pool import LineupPosition, PlayerPool
 from pydfs_lineup_optimizer.exceptions import LineupOptimizerException
 
+from pydfs.config.roster import get_rules
 from pydfs.models import PlayerRecord
 
 
@@ -31,6 +33,68 @@ _PLAYER_RETAIN_DEFAULT = 0.75
 _PLAYER_MIN_PER_POS_DEFAULT = 8
 _EXPOSURE_BIAS_DEFAULT_TARGET = 0.4
 _EXPOSURE_BIAS_WARMUP_LINEUPS = 25
+
+_SINGLE_GAME_MULTIPLIERS: dict[str, dict[str, float]] = {
+    "NFL": {"MVP": 1.5},
+    "NBA": {"MVP": 2.0, "STAR": 1.5, "PRO": 1.2},
+    "MLB": {"MVP": 2.0, "STAR": 1.5},
+    "NHL": {"CAPTAIN": 1.5},
+}
+
+_SINGLE_GAME_ALLOWED_BASE_POSITIONS: dict[str, set[str]] = {
+    "NFL": {"QB", "RB", "WR", "TE", "K"},
+    "NBA": {"PG", "SG", "SF", "PF", "C"},
+    "MLB": {"1B", "2B", "3B", "SS", "OF", "C", "C/1B"},
+    "NHL": {"C", "W", "D"},
+}
+
+
+def _apply_roster_rules_to_optimizer(optimizer, site: str, sport: str) -> None:
+    try:
+        rules = get_rules(site, sport)
+    except KeyError:
+        return
+
+    settings = optimizer.settings
+    current_order = tuple(position.name for position in getattr(settings, "positions", ()))
+    desired_order = tuple(rules.roster_order)
+    current_team_max = getattr(settings, "max_from_one_team", None)
+    changed_positions = current_order != desired_order
+    changed_team_max = current_team_max != rules.team_max_players
+
+    if not changed_positions and not changed_team_max:
+        return
+
+    if changed_positions:
+        slot_positions = rules.slot_positions
+        new_positions: list[LineupPosition] = []
+        for slot in desired_order:
+            allowed = slot_positions.get(slot)
+            if not allowed:
+                fallback = next(
+                    (tuple(pos.positions) for pos in settings.positions if pos.name == slot),
+                    (),
+                )
+                if fallback:
+                    allowed = set(fallback)
+            if not allowed:
+                logger.warning(
+                    "No eligible positions configured for slot %s when applying roster override for %s %s; skipping override",
+                    slot,
+                    site,
+                    sport,
+                )
+                return
+            new_positions.append(LineupPosition(slot, tuple(sorted(allowed))))
+        settings_cls = settings.__class__
+        settings_cls.positions = list(new_positions)
+        settings.positions = list(new_positions)
+        optimizer.player_pool = PlayerPool(settings)
+
+    if changed_team_max:
+        settings_cls = settings.__class__
+        settings_cls.max_from_one_team = rules.team_max_players
+        settings.max_from_one_team = rules.team_max_players
 
 
 def _env_float(name: str, default: float, *, clamp_min: float | None = None, clamp_max: float | None = None) -> float:
@@ -254,6 +318,11 @@ def _to_pydfs_players(records: Sequence[PlayerRecord]):
     dfs_players: List[PydfsPlayer] = []
     for record in records:
         first, last = _split_name(record.name)
+        base_positions = record.metadata.get("base_positions")
+        if base_positions:
+            base_positions_list = list(base_positions)
+        else:
+            base_positions_list = list(record.positions) if record.positions else None
         dfs_players.append(
             PydfsPlayer(
                 player_id=record.player_id,
@@ -266,6 +335,7 @@ def _to_pydfs_players(records: Sequence[PlayerRecord]):
                 projected_ownership=record.metadata.get("projected_ownership"),
                 fppg_floor=record.metadata.get("projection_floor"),
                 fppg_ceil=record.metadata.get("projection_ceil"),
+                original_positions=base_positions_list,
             )
         )
     return dfs_players
@@ -314,6 +384,88 @@ def _filter_player_pool(
     else:
         logger.info("Player pool retained full size (%s players)", len(records))
     return filtered
+
+
+def _expand_single_game_records(
+    records: Sequence[PlayerRecord], *, site: str, sport: str
+) -> list[PlayerRecord]:
+    if site.upper() != "FD_SINGLE":
+        return [record.model_copy() for record in records]
+
+    sport_key = sport.upper()
+    role_map = _SINGLE_GAME_MULTIPLIERS.get(sport_key)
+    if not role_map:
+        return [record.model_copy() for record in records]
+
+    allowed_positions = _SINGLE_GAME_ALLOWED_BASE_POSITIONS.get(sport_key)
+    expanded: list[PlayerRecord] = []
+    for record in records:
+        base_metadata = dict(record.metadata)
+        base_metadata.setdefault("base_player_id", record.player_id)
+        existing_positions = set(record.positions)
+        metadata_positions = base_metadata.get("base_positions")
+        base_positions = list(record.positions)
+        if metadata_positions and not base_positions:
+            base_positions = list(metadata_positions)
+        base_positions = [pos for pos in base_positions if pos]
+        if existing_positions and existing_positions.issubset(set(role_map.keys())):
+            role = next(iter(existing_positions))
+            role_metadata = dict(base_metadata)
+            role_metadata.setdefault("single_game_role", role)
+            role_metadata.setdefault(
+                "single_game_multiplier",
+                role_map.get(role, 1.0),
+            )
+            expanded.append(record.model_copy(update={"metadata": role_metadata}))
+            continue
+
+        base_metadata.setdefault("single_game_role", "BASE")
+        base_metadata.setdefault("single_game_multiplier", 1.0)
+        if not base_positions and metadata_positions:
+            base_positions = list(metadata_positions)
+        if allowed_positions and base_positions:
+            filtered = [pos for pos in base_positions if pos in allowed_positions]
+            if filtered:
+                base_positions = filtered
+        if base_positions:
+            base_metadata["base_positions"] = tuple(base_positions)
+        base_positions_for_variants = base_positions or list(record.positions)
+
+        base_record_positions = list(record.positions)
+        if not base_record_positions and base_positions:
+            base_record_positions = list(base_positions)
+        expanded.append(
+            record.model_copy(
+                update={
+                    "positions": base_record_positions,
+                    "metadata": base_metadata,
+                }
+            )
+        )
+
+        eligible_positions = base_positions_for_variants or list(record.positions)
+        if allowed_positions and eligible_positions:
+            if not any(pos in allowed_positions for pos in eligible_positions):
+                continue
+
+        for role, multiplier in role_map.items():
+            role_metadata = dict(base_metadata)
+            role_metadata["single_game_role"] = role
+            role_metadata["single_game_multiplier"] = multiplier
+            baseline = float(role_metadata.get("baseline_projection", record.projection))
+            role_metadata["baseline_projection"] = baseline * multiplier
+            variant_id = f"{record.player_id}__{role}"
+            expanded.append(
+                record.model_copy(
+                    update={
+                        "player_id": variant_id,
+                        "positions": [role],
+                        "projection": record.projection * multiplier,
+                        "metadata": role_metadata,
+                    }
+                )
+            )
+    return expanded
 
 
 def _apply_bias_to_records(
@@ -820,15 +972,20 @@ def _build_lineups_serial(
 
     active_records = _filter_player_pool(list(records), mandatory_ids=lock_player_ids)
     optimizer = get_optimizer(_resolve_site(site), _resolve_sport(sport))
-    if min_salary is not None and hasattr(optimizer, "min_salary_cap"):
-        optimizer.min_salary_cap = min_salary
+    _apply_roster_rules_to_optimizer(optimizer, site, sport)
+    if min_salary is not None:
+        if hasattr(optimizer, "set_min_salary_cap"):
+            optimizer.set_min_salary_cap(min_salary)
+        elif hasattr(optimizer, "min_salary_cap"):
+            optimizer.min_salary_cap = min_salary
     logger.info(
         "Optimizer salary caps – max=%s min=%s",
         getattr(optimizer, "max_salary", None),
         getattr(optimizer, "min_salary_cap", None),
     )
 
-    dfs_players = _to_pydfs_players(active_records)
+    expanded_records = _expand_single_game_records(active_records, site=site, sport=sport)
+    dfs_players = _to_pydfs_players(expanded_records)
     optimizer.player_pool.load_players(dfs_players)
 
     pool = optimizer.player_pool
@@ -853,7 +1010,7 @@ def _build_lineups_serial(
 
     baseline_lookup = {
         record.player_id: float(record.metadata.get("baseline_projection", record.projection))
-        for record in active_records
+        for record in expanded_records
     }
 
     results: List[LineupResult] = []

--- a/tests/test_ingest_projections.py
+++ b/tests/test_ingest_projections.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 import pytest
 
-from pydfs.ingest import ProjectionRow, merge_player_and_projection_files, rows_to_records
+from pydfs.ingest import (
+    ProjectionRow,
+    infer_site_variant,
+    merge_player_and_projection_files,
+    rows_to_records,
+)
 
 
 def _row(**kwargs):
@@ -35,6 +40,73 @@ def test_rows_to_records_nfl_defense():
 
     records = rows_to_records([row], site="FD", sport="NFL")
     assert records[0].positions == ["D"]
+
+
+def test_rows_to_records_single_game_defense_position_inferred():
+    row = _row(
+        player_id="sgd",
+        name="Dallas Cowboys D/ST",
+        team="DAL",
+        position="",
+        salary="7000",
+        projection="6.8",
+    )
+
+    records = rows_to_records([row], site="FD", sport="NFL")
+    assert records[0].positions == ["D"]
+
+
+def test_rows_to_records_single_game_uses_fallback_by_id():
+    row = _row(
+        player_id="qb1",
+        name="Kirk Cousins",
+        team="MIN",
+        position="",
+        salary="15000",
+        projection="17.4",
+    )
+
+    records = rows_to_records(
+        [row],
+        site="FD_SINGLE",
+        sport="NFL",
+        fallback_positions_by_id={"qb1": ("QB",)},
+    )
+
+    assert records[0].positions == ["QB"]
+    assert records[0].metadata["base_positions"] == ("QB",)
+
+
+def test_rows_to_records_single_game_uses_fallback_by_name():
+    row = _row(
+        player_id="",
+        name="Justin Jefferson",
+        team="MIN",
+        position="",
+        salary="16500",
+        projection="20.1",
+    )
+
+    records = rows_to_records(
+        [row],
+        site="FD_SINGLE",
+        sport="NFL",
+        fallback_positions_by_key={"justinjefferson::MIN": ("WR",)},
+    )
+
+    assert records[0].positions == ["WR"]
+    assert records[0].metadata["base_positions"] == ("WR",)
+
+
+def test_infer_site_variant_detects_single_game_tokens():
+    rows = [
+        _row(player_id="p1", name="Player One", team="BOS", position="MVP", salary="12000", projection="35"),
+        _row(player_id="p2", name="Player Two", team="LAL", position="STAR", salary="10500", projection="28"),
+    ]
+
+    site, sport = infer_site_variant("FD", "NBA", rows)
+    assert site == "FD_SINGLE"
+    assert sport == "NBA"
 
 
 def test_merge_players_and_projections(tmp_path: Path):

--- a/tests/test_optimizer_service.py
+++ b/tests/test_optimizer_service.py
@@ -4,7 +4,12 @@ import pytest
 
 from pydfs.models import PlayerRecord
 from pydfs.optimizer import build_lineups
-from pydfs.optimizer.service import _perturb_projections, _perturbation_window, _apply_bias_to_records
+from pydfs.optimizer.service import (
+    _apply_bias_to_records,
+    _expand_single_game_records,
+    _perturb_projections,
+    _perturbation_window,
+)
 
 
 def _sample_pool() -> list[PlayerRecord]:
@@ -124,3 +129,63 @@ def test_apply_bias_to_records_adjusts_projection():
     assert biased[1].projection == pytest.approx(6.4)
     assert biased[0].metadata["bias_factor"] == pytest.approx(1.2)
     assert biased[1].metadata["bias_factor"] == pytest.approx(0.8)
+
+
+def test_expand_single_game_records_creates_variants():
+    base = PlayerRecord(
+        player_id="p1",
+        name="Quarterback",
+        team="DAL",
+        positions=["QB"],
+        salary=9000,
+        projection=20.0,
+        metadata={"baseline_projection": 20.0},
+    )
+
+    expanded = _expand_single_game_records([base], site="FD_SINGLE", sport="NFL")
+    ids = {record.player_id for record in expanded}
+    assert base.player_id in ids
+    assert f"{base.player_id}__MVP" in ids
+    mvp = next(record for record in expanded if record.player_id.endswith("__MVP"))
+    assert mvp.projection == pytest.approx(30.0)
+    assert mvp.positions == ["MVP"]
+    assert mvp.metadata["single_game_role"] == "MVP"
+
+
+def test_expand_single_game_records_uses_base_positions_metadata():
+    base = PlayerRecord(
+        player_id="wr1",
+        name="Star Receiver",
+        team="DAL",
+        positions=[],
+        salary=11000,
+        projection=24.5,
+        metadata={"baseline_projection": 24.5, "base_positions": ("WR",)},
+    )
+
+    expanded = _expand_single_game_records([base], site="FD_SINGLE", sport="NFL")
+    base_variant = next(record for record in expanded if record.player_id == "wr1")
+    assert base_variant.positions == ["WR"]
+    assert base_variant.metadata["base_positions"] == ("WR",)
+    mvp_variant = next(record for record in expanded if record.player_id.endswith("__MVP"))
+    assert mvp_variant.metadata["base_positions"] == ("WR",)
+
+
+def test_build_lineups_single_game_generates_mvp_slot():
+    pool = [
+        PlayerRecord(player_id="qb1", name="Quarterback", team="DAL", positions=["QB"], salary=9000, projection=20.0),
+        PlayerRecord(player_id="rb1", name="Running Back 1", team="DAL", positions=["RB"], salary=7500, projection=16.0),
+        PlayerRecord(player_id="wr1", name="Wide Receiver 1", team="PHI", positions=["WR"], salary=7200, projection=15.0),
+        PlayerRecord(player_id="wr2", name="Wide Receiver 2", team="PHI", positions=["WR"], salary=6800, projection=14.2),
+        PlayerRecord(player_id="te1", name="Tight End", team="DAL", positions=["TE"], salary=6400, projection=13.0),
+        PlayerRecord(player_id="k1", name="Kicker", team="PHI", positions=["K"], salary=5000, projection=9.5),
+    ]
+
+    output = build_lineups(pool, site="FD_SINGLE", sport="NFL", n_lineups=1, max_exposure=1.0)
+
+    assert len(output.lineups) == 1
+    lineup = output.lineups[0]
+    assert len(lineup.players) == 6
+    assert any("MVP" in player.positions for player in lineup.players)
+    mvp_count = sum(1 for player in lineup.players if player.player_id.endswith("__MVP"))
+    assert mvp_count == 1


### PR DESCRIPTION
## Summary
- restore base positions when FanDuel single-game exports omit the position column by loading classic roster data as fallback
- carry base position metadata into optimizer expansion so MVP variants retain original eligibility
- cover the new fallback and expansion logic with regression tests
- expand FanDuel single-game NFL rosters to six slots by aligning optimizer settings with the roster configuration
- update the single-game optimizer regression to verify a six-player lineup with an MVP entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68df023b44fc8328b62daed19a482b9a