### PR TITLE
Enhance projection merge reporting for manual review

### DIFF
--- a/src/pydfs/api/__init__.py
+++ b/src/pydfs/api/__init__.py
@@ -27,6 +27,7 @@ from pydfs.api.schemas import (
     LineupPlayerResponse,
     LineupRequest,
     LineupResponse,
+    ManualReviewItemResponse,
     MappingPreviewResponse,
     PlayerUsageResponse,
     PoolFilterRequest,
@@ -51,6 +52,8 @@ DEFAULT_PLAYERS_MAPPING = {
     "position": "Position",
     "salary": "Salary",
     "projection": "FPPG",
+    "game": "Game",
+    "opponent": "Opponent",
 }
 
 DEFAULT_PROJECTION_MAPPING = {
@@ -170,6 +173,20 @@ def _report_to_mapping(report: MappingPreviewResponse | MergeReport | dict) -> M
             matched_players=report.matched_players,
             players_missing_projection=report.players_missing_projection,
             unmatched_projection_rows=report.unmatched_projection_rows,
+            manual_review=[
+                ManualReviewItemResponse(
+                    identifier=item.identifier,
+                    name=item.name,
+                    team=item.team,
+                    team_abbreviation=item.team_abbreviation or None,
+                    projection=item.projection,
+                    salary=item.salary,
+                    game=item.game,
+                    reason=item.reason,
+                )
+                for item in report.manual_review
+            ],
+            ignored_projection_rows=report.ignored_projection_rows,
         )
     if isinstance(report, dict):
         return MappingPreviewResponse.model_validate(report)

--- a/src/pydfs/api/schemas/mapping.py
+++ b/src/pydfs/api/schemas/mapping.py
@@ -8,8 +8,21 @@ class MappingPayload(BaseModel):
     projection_mapping: dict[str, str] = Field(default_factory=dict)
 
 
+class ManualReviewItemResponse(BaseModel):
+    identifier: str
+    name: str
+    team: str
+    team_abbreviation: str | None = None
+    projection: float | None = None
+    salary: int | None = None
+    game: str | None = None
+    reason: str
+
+
 class MappingPreviewResponse(BaseModel):
     total_players: int
     matched_players: int
     players_missing_projection: list[str]
     unmatched_projection_rows: list[str]
+    manual_review: list[ManualReviewItemResponse] = Field(default_factory=list)
+    ignored_projection_rows: list[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- capture game and opponent metadata while parsing CSV rows so projection merges have richer context
- extend NFL merge logic to classify unmatched projections, surface manual review entries, and respect manual overrides
- expose the new merge details through the mapping preview schema and add coverage for manual review flows

## Testing
- pytest tests/test_ingest_projections.py

------
https://chatgpt.com/codex/tasks/task_b_68e3cc4e25d08328aa9ae77d83008a08